### PR TITLE
Phone number can be transformed to proper format

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,11 @@ Which uses the Google lib https://github.com/googlei18n/libphonenumber.
 const myCustomJoi = Joi.extend(require('joi-phone-number'));
 
 myCustomJoi.string().phoneNumber().validate('+32494567324');
+myCustomJoi.string().phoneNumber('BE').validate('+32494567324');
+
+// phone number can be transformed to proper format
+myCustomJoi.string().phoneNumber('BE', 'e164').validate('494322456'); // '+32494322456'
+myCustomJoi.string().phoneNumber('BE', 'international').validate('494322456'); // '+32 494 32 24 56'
+myCustomJoi.string().phoneNumber('BE', 'national').validate('494322456'); // '0494 32 24 56'
+myCustomJoi.string().phoneNumber('BE', 'rfc3966').validate('494322456'); // 'tel:+32-494-32-24-56'
 ```

--- a/lib/__tests__/joiPhoneNumber.test.js
+++ b/lib/__tests__/joiPhoneNumber.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Joi = require('joi');
 const JoiPhoneNumber = require('../index.js');
 
@@ -35,5 +37,21 @@ describe('joiPhoneNumber', () => {
     successTests.forEach(testCase => {
       expect(schema.validate(testCase).error).toBeNull();
     });
+  });
+
+  it('format', () => {
+    const joi = Joi.extend(JoiPhoneNumber);
+
+    let schema = joi.string().phoneNumber('BE', 'e164');
+    expect(schema.validate('494322456').value).toBe('+32494322456');
+
+    schema = joi.string().phoneNumber('BE', 'international');
+    expect(schema.validate('494322456').value).toBe('+32 494 32 24 56');
+
+    schema = joi.string().phoneNumber('BE', 'national');
+    expect(schema.validate('494322456').value).toBe('0494 32 24 56');
+
+    schema = joi.string().phoneNumber('BE', 'rfc3966');
+    expect(schema.validate('494322456').value).toBe('tel:+32-494-32-24-56');
   });
 });

--- a/lib/__tests__/joiPhoneNumber.test.js
+++ b/lib/__tests__/joiPhoneNumber.test.js
@@ -42,16 +42,34 @@ describe('joiPhoneNumber', () => {
   it('format', () => {
     const joi = Joi.extend(JoiPhoneNumber);
 
-    let schema = joi.string().phoneNumber('BE', 'e164');
+    let schema = joi.string().phoneNumber({
+      defaultCountry: 'BE',
+      format: 'e164'
+    });
     expect(schema.validate('494322456').value).toBe('+32494322456');
 
-    schema = joi.string().phoneNumber('BE', 'international');
+    schema = joi.string().phoneNumber({
+      defaultCountry: 'BE',
+      format: 'international'
+    });
     expect(schema.validate('494322456').value).toBe('+32 494 32 24 56');
 
-    schema = joi.string().phoneNumber('BE', 'national');
+    schema = joi.string().phoneNumber({
+      defaultCountry: 'BE',
+      format: 'national'
+    });
     expect(schema.validate('494322456').value).toBe('0494 32 24 56');
 
-    schema = joi.string().phoneNumber('BE', 'rfc3966');
+    schema = joi.string().phoneNumber({
+      defaultCountry: 'BE',
+      format: 'rfc3966'
+    });
     expect(schema.validate('494322456').value).toBe('tel:+32-494-32-24-56');
+
+    schema = joi.string().phoneNumber({
+      defaultCountry: 'BE',
+      format: 'rfc3966'
+    });
+    expect(schema.validate('494322456', {convert: false}).value).toBe('494322456');
   });
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
-const PhoneUtil = require('google-libphonenumber').PhoneNumberUtil.getInstance();
+const libphonenumber = require('google-libphonenumber');
+const PhoneUtil = libphonenumber.PhoneNumberUtil.getInstance();
+const PhoneNumberFormat = libphonenumber.PhoneNumberFormat;
 
 /**
  * Allows you to do `Joi.string().phoneNumber()`
@@ -13,17 +15,24 @@ module.exports = joi => ({
   },
   rules: [{
     name: 'phoneNumber',
+    params: {
+      /**
+       * We will use specified country code (phoneNumber('BE')) or 'US' if no
+       * country code provided in phone number (0494...). Numbers with country
+       * code (+3249...) will use the data from the number and not the default.
+       */
+      defaultCountry: joi.string().default('US'),
+      format: joi.only('e164', 'international', 'national', 'rfc3966')
+    },
     validate(params, value, state, options) {
       try {
-        /**
-         * FUTURE
-         * If no country code is provided (0494...) assume it is a US number
-         * Which is not super correct but we don't know the country of the user atm
-         * Numbers with country code (+3249...) will use the data from the number and not the 'US' default
-         */
-        PhoneUtil.parse(value, 'US');
+        const proto = PhoneUtil.parse(value, params.defaultCountry);
+        if (!params.format) {
+          return value;
+        }
 
-        return value;
+        const format = getFormat(params.format);
+        return PhoneUtil.format(proto, format);
       } catch (err) {
         // Generate an error, state and options need to be passed
         return this.createError('string.phonenumber', {value}, state, options);
@@ -31,3 +40,12 @@ module.exports = joi => ({
     }
   }]
 });
+
+function getFormat(format) {
+  switch (format) { // eslint-disable-line default-case
+    case 'e164': return PhoneNumberFormat.E164;
+    case 'international': return PhoneNumberFormat.INTERNATIONAL;
+    case 'national': return PhoneNumberFormat.NATIONAL;
+    case 'rfc3966': return PhoneNumberFormat.RFC3966;
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,22 +16,24 @@ module.exports = joi => ({
   rules: [{
     name: 'phoneNumber',
     params: {
-      /**
-       * We will use specified country code (phoneNumber('BE')) or 'US' if no
-       * country code provided in phone number (0494...). Numbers with country
-       * code (+3249...) will use the data from the number and not the default.
-       */
-      defaultCountry: joi.string().default('US'),
-      format: joi.only('e164', 'international', 'national', 'rfc3966')
+      opts: joi.object().keys({
+        /**
+         * We will use specified country code (phoneNumber('BE')) or 'US' if no
+         * country code provided in phone number (0494...). Numbers with country
+         * code (+3249...) will use the data from the number and not the default.
+         */
+        defaultCountry: joi.string(),
+        format: joi.only('e164', 'international', 'national', 'rfc3966')
+      }).default({defaultCountry: 'US'})
     },
     validate(params, value, state, options) {
       try {
-        const proto = PhoneUtil.parse(value, params.defaultCountry);
-        if (!params.format) {
+        const proto = PhoneUtil.parse(value, params.opts.defaultCountry);
+        if (!options.convert || !params.opts.format) {
           return value;
         }
 
-        const format = getFormat(params.format);
+        const format = PhoneNumberFormat[params.opts.format.toUpperCase()];
         return PhoneUtil.format(proto, format);
       } catch (err) {
         // Generate an error, state and options need to be passed
@@ -40,12 +42,3 @@ module.exports = joi => ({
     }
   }]
 });
-
-function getFormat(format) {
-  switch (format) { // eslint-disable-line default-case
-    case 'e164': return PhoneNumberFormat.E164;
-    case 'international': return PhoneNumberFormat.INTERNATIONAL;
-    case 'national': return PhoneNumberFormat.NATIONAL;
-    case 'rfc3966': return PhoneNumberFormat.RFC3966;
-  }
-}


### PR DESCRIPTION
```js
myCustomJoi.string().phoneNumber('BE', 'e164').validate('494322456'); // '+32494322456'
```
Default country code can be set with option (fix #12)