### PR TITLE
test: add test case to validate e164 format

### DIFF
--- a/lib/__tests__/joiPhoneNumber.test.js
+++ b/lib/__tests__/joiPhoneNumber.test.js
@@ -30,6 +30,17 @@ describe('joiPhoneNumber', () => {
     expect(schema.validate('011 69 37 83').error).toBeNull(); // Should work with the BE fallback
   });
 
+  it('validates e164 format', () => {
+    const joi = Joi.extend(JoiPhoneNumber);
+    const schema = joi.string().phoneNumber({
+      format: 'e164'
+    });
+
+    expect(schema.validate('32494555890').error).toBeInstanceOf(Error);
+
+    expect(schema.validate('+32494555890').error).toBeNull();
+  });
+
   it('formats', () => {
     const joi = Joi.extend(JoiPhoneNumber);
 


### PR DESCRIPTION
Greetings!
Thanks for maintaining the package. It serves the purpose very well and actively using in the project of mine.

After the latest upgrade to `3.0.0` my previous way of number validation stopped working, even though it does not seem that breaking changes were intended to change the way validation works.

In this PR I've added a test case for validation of `e164` format without `defaultCountry` option passed. In version `2.1.1` this test passes, so I would expect that it should still be possible to validate if value is a valid `e164` phone number regardless of the country.

This PR is to highlight encountered issue, but fix is not included.