### PR TITLE
feat: add strict validation to phone number as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,6 @@ myCustomJoi.string().phoneNumber({ defaultCountry: 'BE', format: 'e164' }).valid
 myCustomJoi.string().phoneNumber({ defaultCountry: 'BE', format: 'international' }).validate('494322456'); // '+32 494 32 24 56'
 myCustomJoi.string().phoneNumber({ defaultCountry: 'BE', format: 'national' }).validate('494322456'); // '0494 32 24 56'
 myCustomJoi.string().phoneNumber({ defaultCountry: 'BE', format: 'rfc3966' }).validate('494322456'); // 'tel:+32-494-32-24-56'
+myCustomJoi.string().phoneNumber({ defaultCountry: 'US', strict: true }).validate('7777777777'); // validation error
+myCustomJoi.string().phoneNumber({ defaultCountry: 'US'}).validate('7777777777'); // 7777777777
 ```

--- a/lib/__tests__/joiPhoneNumber.test.js
+++ b/lib/__tests__/joiPhoneNumber.test.js
@@ -72,10 +72,14 @@ describe('joiPhoneNumber', () => {
 
   it('strict validates', () => {
     const joi = Joi.extend(JoiPhoneNumber);
-    const schema = joi.string().phoneNumber({strict: true, format: 'e164'});
+    const strict = joi.string().phoneNumber({defaultCountry: 'US', strict: true});
+    const notStrict = joi.string().phoneNumber({defaultCountry: 'US'});
+    const numbers = ['7777777777', '1234567890'];
 
-    expect(schema.validate('+1494322456').error).toBeInstanceOf(Error);
-    expect(schema.validate('+15417543010').error).toBeNull();
+    for (const number of numbers) {
+      expect(strict.validate(number).error.name).toEqual('ValidationError');
+      expect(notStrict.validate(number).error).toEqual(null);
+    }
   });
 
   it('validates and formats without a country', () => {

--- a/lib/__tests__/joiPhoneNumber.test.js
+++ b/lib/__tests__/joiPhoneNumber.test.js
@@ -70,6 +70,14 @@ describe('joiPhoneNumber', () => {
     expect(schema.validate('494322456', {convert: false}).value).toBe('494322456');
   });
 
+  it('strict validates', () => {
+    const joi = Joi.extend(JoiPhoneNumber);
+    const schema = joi.string().phoneNumber({strict: true, format: 'e164'});
+
+    expect(schema.validate('+1494322456').error).toBeInstanceOf(Error);
+    expect(schema.validate('+15417543010').error).toBeNull();
+  });
+
   it('validates and formats without a country', () => {
     const joi = Joi.extend(JoiPhoneNumber);
     const schema = joi.string().phoneNumber({

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ module.exports = joi => ({
         const proto = internals.parse(value, params.opts.defaultCountry);
 
         if (params.opts.strict && !PhoneUtil.isValidNumber(proto)) {
-          throw Error('StrictPhoneNumber');
+          throw new Error('StrictPhoneNumber');
         }
 
         if (!options.convert || !params.opts.format) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,12 +28,18 @@ module.exports = joi => ({
          * Numbers with country code (+3249...) will use the data from the number and not the default.
          */
         defaultCountry: joi.array().items(joi.string()).single(),
-        format: joi.string().only('e164', 'international', 'national', 'rfc3966')
-      }).default({defaultCountry: ['US', 'BE']}).min(1)
+        format: joi.string().only('e164', 'international', 'national', 'rfc3966'),
+        strict: joi.boolean()
+      }).default({defaultCountry: ['US', 'BE'], strict: false}).min(1)
     },
     validate(params, value, state, options) {
       try {
         const proto = internals.parse(value, params.opts.defaultCountry);
+
+        if (params.opts.strict && !PhoneUtil.isValidNumber(proto)) {
+          throw Error('StrictPhoneNumber');
+        }
+
         if (!options.convert || !params.opts.format) {
           return value;
         }
@@ -41,11 +47,11 @@ module.exports = joi => ({
         const format = PhoneNumberFormat[params.opts.format.toUpperCase()];
         return PhoneUtil.format(proto, format);
       } catch (err) {
-        const knownErrors = ['Invalid country calling code', 'The string supplied did not seem to be a phone number'];
+        const knownErrors = ['Invalid country calling code', 'The string supplied did not seem to be a phone number', 'StrictPhoneNumber'];
         // We ignore the next line for line coverage since we should always hit it but if we have a regression in our code we still want to surface that instead of just returning the default error
         /* istanbul ignore next */
         if (knownErrors.includes(err.message)) {
-        // Generate an error, state and options need to be passed
+          // Generate an error, state and options need to be passed
           return this.createError('string.phonenumber', {value}, state, options);
         }
 


### PR DESCRIPTION
Resolves #57.

Adds an option `strict` to define if `isValidNumber` should be checked against the formatted number. 

This is a quick first draft, will need to update the `README.md` & add some more tests. 

Let me know 