### PR TITLE
feat: allow Joi references to be passed as options

### DIFF
--- a/lib/__tests__/joiPhoneNumber.test.js
+++ b/lib/__tests__/joiPhoneNumber.test.js
@@ -55,6 +55,28 @@ describe('joiPhoneNumber', () => {
     expect(schema.validate('494322456', {convert: false}).value).toBe('494322456');
   });
 
+  it('formats with reference', () => {
+    const joi = Joi.extend(JoiPhoneNumber);
+
+    let schema = joi.string().phoneNumber({defaultCountry: Joi.ref('$country'), format: 'e164'});
+    expect(schema.validate('494322456', {context: {country: 'BE'}}).value).toBe('+32494322456');
+
+    schema = joi.string().phoneNumber({defaultCountry: Joi.ref('$country'), format: 'international'});
+    expect(schema.validate('494322456', {context: {country: 'BE'}}).value).toBe('+32 494 32 24 56');
+
+    schema = joi.string().phoneNumber({defaultCountry: Joi.ref('$country'), format: 'national'});
+    expect(schema.validate('494322456', {context: {country: 'BE'}}).value).toBe('0494 32 24 56');
+
+    schema = joi.string().phoneNumber({defaultCountry: Joi.ref('$country'), format: 'rfc3966'});
+    expect(schema.validate('494322456', {context: {country: 'BE'}}).value).toBe('tel:+32-494-32-24-56');
+
+    schema = joi.string().phoneNumber({defaultCountry: Joi.ref('$country'), format: 'rfc3966'});
+    expect(schema.validate('494322456', {convert: false, context: {country: 'BE'}}).value).toBe('494322456');
+
+    schema = joi.string().phoneNumber({defaultCountry: Joi.ref('$country'), format: 'rfc3966'});
+    expect(schema.validate('494322456', {convert: false, context: {country: 'BE'}}).value).toBe('494322456');
+  });
+
   it('strict validates', () => {
     const joi = Joi.extend(JoiPhoneNumber);
     const strictSchema = joi.string().phoneNumber({defaultCountry: 'US', strict: true});
@@ -95,7 +117,7 @@ describe('joiPhoneNumber', () => {
     expect(() => {
       const schema = joi.string().phoneNumber({defaultCountry: 1});
       schema.validate('011 999 7083');
-    }).toThrow('"defaultCountry" must be a string');
+    }).toThrow('defaultCountry must be a string, array of strings or reference');
   });
 
   it('errors on wrong format options', () => {
@@ -104,6 +126,13 @@ describe('joiPhoneNumber', () => {
     expect(() => {
       const schema = joi.string().phoneNumber({format: 'ppp'});
       schema.validate('011 999 7083');
-    }).toThrow('"format" must be one of [e164, international, national, rfc3966]');
+    }).toThrow('format must be one of [e164, international, national, rfc3966] or reference');
+  });
+
+  it('errors on wrong format options as reference', () => {
+    const joi = Joi.extend(JoiPhoneNumber);
+    const schema = joi.string().phoneNumber({format: Joi.ref('$format')});
+
+    expect(schema.validate('011 999 7083', {context: {format:'qqq'}}).error).toBeInstanceOf(Error);
   });
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,17 +14,6 @@ const internals = {};
  * @return {Object} Joi plugin object
  */
 module.exports = joi => {
-  const opts = joi.object().keys({
-    /**
-     * We will use the specified country code or 'US', with fallback 'BE', if no
-     * country code provided in phone number (0494...).
-     * Numbers with country code (+3249...) will use the data from the number and not the default.
-     */
-    defaultCountry: joi.array().items(joi.string()).single(),
-    strict: joi.boolean(),
-    format: joi.string().valid('e164', 'international', 'national', 'rfc3966')
-  }).default({defaultCountry: ['US', 'BE']}).min(1);
-
   return {
     base: joi.string(),
     type: 'string',
@@ -33,24 +22,50 @@ module.exports = joi => {
     },
     rules: {
       phoneNumber: {
-        method(options) {
-          return this.$_addRule({name: 'phoneNumber', args: {options}});
+        /**
+         * We will use the specified country code or 'US', with fallback 'BE', if no
+         * country code provided in phone number (0494...).
+         * Numbers with country code (+3249...) will use the data from the number and not the default.
+         */
+        method({defaultCountry, strict, format} = { defaultCountry:  ['US', 'BE'] }) {
+          return this.$_addRule({name: 'phoneNumber', args: {defaultCountry, strict, format}});
         },
+        args: [
+          {
+            name: 'defaultCountry',
+            ref: true,
+            assert: value => Array.isArray(value)
+              ? value.every(country => typeof country === 'string' && country.length === 2)
+              : typeof value === 'string' && value.length === 2,
+            message: 'must be a string, array of strings'
+          },
+          {
+            name: 'strict',
+            ref: true,
+            assert: value => typeof value === 'boolean',
+            message: 'must be a boolean'
+          },
+          {
+            name: 'format',
+            ref: true,
+            assert: value => ['e164', 'international', 'national', 'rfc3966'].includes(value),
+            message: 'must be one of [e164, international, national, rfc3966]'
+          }
+        ],
         validate(value, {prefs, error}, args) {
-          const options = joi.attempt(args.options, opts);
-
+          const countries = Array.isArray(args.defaultCountry) || !args.defaultCountry ? args.defaultCountry : [args.defaultCountry];
           try {
-            const proto = internals.parse(value, options.defaultCountry);
+            const proto = internals.parse(value, countries);
 
-            if (options.strict && !PhoneUtil.isValidNumber(proto)) {
+            if (args.strict && !PhoneUtil.isValidNumber(proto)) {
               throw new Error('StrictPhoneNumber');
             }
 
-            if (!prefs.convert || !options.format) {
+            if (!prefs.convert || !args.format) {
               return value;
             }
 
-            const format = PhoneNumberFormat[options.format.toUpperCase()];
+            const format = PhoneNumberFormat[args.format.toUpperCase()];
             value = PhoneUtil.format(proto, format);
             return value;
           } catch (err) {


### PR DESCRIPTION
Uses Joi's built-in handling of arguments to effortlessly handle references. The args array is unfortunately not too well documented

fix #50 